### PR TITLE
Don't load LinearAlgebra before of module

### DIFF
--- a/src/ExtendedKronigPennyMatrix.jl
+++ b/src/ExtendedKronigPennyMatrix.jl
@@ -1,9 +1,6 @@
-
-__precompile__(true)
+module ExtendedKronigPennyMatrix
 
 using LinearAlgebra
-
-module ExtendedKronigPennyMatrix
 using Unitful
 
 include("basic.jl")


### PR DESCRIPTION
This is not valid and only worked previously, I believe, because LinearAlgebra used to be in the sysimage